### PR TITLE
[ut] file open/write/read/close UT 추가

### DIFF
--- a/SSD/SSD.vcxproj
+++ b/SSD/SSD.vcxproj
@@ -102,7 +102,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions); UNIT_TEST</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
@@ -130,8 +130,10 @@
     <ClCompile Include="SSD.cpp">
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'"> %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
+    <ClCompile Include="SSD_Interface.cpp" />
     <ClCompile Include="UT\UT.cpp">
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'"> %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'"> %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/SSD/SSD.vcxproj.filters
+++ b/SSD/SSD.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gmock\gmock-all.cc">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="SSD_Interface.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/SSD/SSD_Interface.cpp
+++ b/SSD/SSD_Interface.cpp
@@ -1,22 +1,48 @@
 #include "iostream"
 #include "fstream"
+#include <string>
+#include <iomanip>
+#include "stdexcept"
+
+using namespace std;
 
 class FILEIO {
 	virtual bool open(const std::string& filename) = 0;
+	virtual void write(const int& LBA, const unsigned int& data) = 0;
 };
 class SSDInterface : public FILEIO {
 public:
 	 bool open(const std::string& filename) override {
-		file_.open(filename, std::ios::out | std::ios::binary);
+		if (file_.is_open()) {
+			file_.close();
+		}
+		file_.open(filename, std::ios::in | std::ios::out | std::ios::binary | std::ios::trunc);
 		return file_.is_open();
 	}
 	bool isOpen() const {
 		return file_.is_open();
 	}
-	void write(const std::string& data) {
+	void write(const int& LBA, const unsigned int& data) {
 		if (file_.is_open()) {
-			file_ << data;
+			file_.seekp(0, std::ios::end);  // 파일 끝으로 이동 후 기록
+			file_ << std::setw(3) << LBA << std::setw(10) << data << "\n";  // LBA(3자리), 데이터(10자리) 고정 길이 저장
+			file_.flush();
+		}			
+	}
+
+	unsigned int read(const int& LBA) {
+		std::string data;
+
+		int readLBA;
+		unsigned int readData;
+		file_.seekg(0, std::ios::beg);
+		while (file_ >> readLBA >> readData) {
+			if (readLBA == LBA) {
+				return readData;
+			}
 		}
+
+		return 0;
 	}
 	void close() {
 		if (file_.is_open()) {
@@ -24,8 +50,6 @@ public:
 		}
 	}
 
-
-
 protected:
-	std::ofstream file_;
+	std::fstream file_;
 };

--- a/SSD/UT/UT.cpp
+++ b/SSD/UT/UT.cpp
@@ -11,34 +11,44 @@ public:
 
 class MockFile : public SSDInterface {
 public:
-	MOCK_METHOD(bool, open, (const std::string& filename), ());
+	MOCK_METHOD(bool, open, (const std::string& filename), (override));
+	MOCK_METHOD(void, write, (const int& LBA, const unsigned int& data), (override));
 };
 
 TEST_F(SSDTestFixture, FileOpen) {
-	MockFile file;
-	EXPECT_CALL(file, open("ssd_nand.txt")).WillRepeatedly(Return(true));
-
 	SSDInterface ssdIO;
 	EXPECT_EQ(true, ssdIO.open("ssd_nand.txt"));
 }
 
 TEST_F(SSDTestFixture, FileOpenCheck) {
-	MockFile file;
-	EXPECT_CALL(file, open("ssd_nand.txt")).WillRepeatedly(Return(true));
-
 	SSDInterface ssdIO;
+	ssdIO.open("ssd_nand.txt");
 	EXPECT_EQ(true, ssdIO.isOpen());
 }
 
 TEST_F(SSDTestFixture, FileClose) {
-	MockFile file;
-    EXPECT_CALL(file, open("ssd_nand.txt")).WillRepeatedly(Return(false));
-
 	SSDInterface ssdIO;
 	ssdIO.close();
 
 	EXPECT_EQ(false, ssdIO.isOpen());
 }
+
+TEST_F(SSDTestFixture, FileReadAtFileBegin) {
+	SSDInterface ssdIO;
+	ssdIO.open("ssd_nand.txt");
+	unsigned int data = 0x12345678;
+	ssdIO.write(0, data);
+	EXPECT_EQ(data, ssdIO.read(0));
+
+	data = 0x3;
+	ssdIO.write(1, data);
+	EXPECT_EQ(data, ssdIO.read(1));
+
+	data = 0x324567;
+	ssdIO.write(2, data);
+	EXPECT_EQ(data, ssdIO.read(2));
+}
+
 
 // (invalide check) Read Wrie °øÅëºÎ
 TEST_F(SSDTestFixture, invalidecheck1) {

--- a/SSD/UT/UT.cpp
+++ b/SSD/UT/UT.cpp
@@ -9,12 +9,6 @@ public:
 	SSDInterface* SSDIn;
 };
 
-class MockFile : public SSDInterface {
-public:
-	MOCK_METHOD(bool, open, (const std::string& filename), (override));
-	MOCK_METHOD(void, write, (const int& LBA, const unsigned int& data), (override));
-};
-
 TEST_F(SSDTestFixture, FileOpen) {
 	SSDInterface ssdIO;
 	EXPECT_EQ(true, ssdIO.open("ssd_nand.txt"));


### PR DESCRIPTION
### [제목]:
[ut] file open/write/read/close UT 추가

### [내용]:
fstream 이용한, file open/close/write/read 동작에 대한 UT 입니다. 
이전 commit에서 ofstream 을 사용하면서 read 안되는 현상이 있어 fstream 으로 변경


### [UT 수행 내용]:
write/read 동작 확인
